### PR TITLE
Fix possible exploit

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ class Config():
 
         try:
             with open(fileName, 'r') as ymlfile:
-                cfg = yaml.load(ymlfile)
+                cfg = yaml.safe_load(ymlfile)
         except Exception as e:
             print(e)
             input("Press any key to exit the program")


### PR DESCRIPTION
That's a real quick, but important fix for that message, that pops up in the beginning:
config.py:14: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.

See here:
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation